### PR TITLE
Update signalstickers domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Run `stickersbot --help` to see all available options.
 
 ## Usage
 
-* To get sticker packs, browse https://signalstickers.com/ and copy the URL of the pack you want (the link in the "+ Add to Signal" button, an URL starting with ``https://signal.art/addstickers``) and send the pack URL to the bot in private, the bot will send you a zip with the sticker pack.
+* To get sticker packs, browse https://signalstickers.org/ and copy the URL of the pack you want (the link in the "+ Add to Signal" button, an URL starting with ``https://signal.art/addstickers``) and send the pack URL to the bot in private, the bot will send you a zip with the sticker pack.
 * To create an sticker from a normal image send the image to the bot and it will remove the background and send you back the image as sticker.
 * Send any text to the bot to search packs matching the given text.
 * Send an emoji to the bot to get a random sticker associated with that emoji.


### PR DESCRIPTION
The domain was set to https://signalstickers.com which looks to be a bad domain, the real website is .org.

Feel free to close this PR and correct it yourself, this is a very minor and silly thing I noticed that I don't need credit for.